### PR TITLE
Moved user_folder creation before logger configuration

### DIFF
--- a/source/imperialism_remake/start.py
+++ b/source/imperialism_remake/start.py
@@ -167,6 +167,10 @@ def main():
 
     user_folder = get_user_directory()
 
+    # if not exist, create user folder
+    if not os.path.isdir(user_folder):
+        os.mkdir(user_folder)
+
     # determine DEBUG_MODE from runtime arguments
     from imperialism_remake.base import switches
     args = get_arguments()
@@ -177,10 +181,6 @@ def main():
 
     # set start directory
     set_start_directory(logger)
-
-    # if not exist, create user folder
-    if not os.path.isdir(user_folder):
-        os.mkdir(user_folder)
 
     # import some base libraries
     import imperialism_remake.base.tools as tools


### PR DESCRIPTION
Just a tiny change to fix first-time startup when ~/.config/imperialism_remake does not yet exist. Tested on macOS and Ubuntu 16.04 (well, it starts--I didn't run the actual tests...)