### PR TITLE
Absolute import in `start.py` prevents startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ environment.pickle
 # ours
 source/imperialism_remake/data/manual
 /build
+
+# Mac
+.DS_Store
+
+# emacs
+*~
+\#*\#

--- a/source/imperialism_remake/start.py
+++ b/source/imperialism_remake/start.py
@@ -150,10 +150,6 @@ def main():
     if QtCore.QT_VERSION < 0x50500:
         raise RuntimeError('Qt version of PyQt5 must be 5.5 at least.')
 
-    # fix PyQt5 exception eating
-    from imperialism_remake.lib import qt
-    qt.fix_pyqt5_exception_eating()
-
     # Add the parent directory of the package directory to Python's search path.
     # This allows the import of the 'imperialism_remake' modules.
     # This is required at least for Linux distributions of Python3, since the current working
@@ -161,6 +157,10 @@ def main():
     source_directory = os.path.realpath(os.path.join(os.path.abspath(os.path.dirname(__file__)), os.path.pardir))
     if source_directory not in sys.path:
         sys.path.insert(0, source_directory)
+
+    # fix PyQt5 exception eating
+    from imperialism_remake.lib import qt
+    qt.fix_pyqt5_exception_eating()
 
     user_folder = get_user_directory()
 


### PR DESCRIPTION
This is another tiny pull request. In the recent update to imports, something changed that prevented the game from starting via command line in Linux and macOS. I thought at first that a lot of imports needed to be fixed, but it turned out that there was just one absolute import in `start.py` that occurred before `sys.path` was extended.

To be honest, imports and dependencies still look a little messy to me, but I am not an expert on Python imports and haven't done many projects this large, so I can't say if there's an objectively better way. I'd be interested in a discussion about this if anyone else is, but it's not a big deal, and there are better things to spend time on anyway.

Also it looks like a commit with some changes to `.gitignore` made it in. I added these because macOS adds `.DS_Store` files everywhere for search indexing, and emacs makes backup files left and right too. It shouldn't affect anything else, though, so it should be fine adding that upstream.